### PR TITLE
refactor: remove any from chunk utility and add tests

### DIFF
--- a/src/app/lib/lodash.test.ts
+++ b/src/app/lib/lodash.test.ts
@@ -6,13 +6,24 @@ describe("chunk", () => {
     expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
   });
 
+  test("size が配列長を超える場合は1チャンクだけ返す", () => {
+    expect(chunk([1, 2, 3], 10)).toEqual([[1, 2, 3]]);
+  });
+
   test("入力配列が空の場合は空配列を返す", () => {
     expect(chunk([], 3)).toEqual([]);
   });
 
-  test("size が 1 未満の場合は空配列を返す", () => {
-    expect(chunk([1, 2, 3], 0)).toEqual([]);
-    expect(chunk([1, 2, 3], -1)).toEqual([]);
+  test("size が正の整数でない場合は TypeError を投げる", () => {
+    expect(() => chunk([1, 2, 3], 0)).toThrow(
+      new TypeError("chunk size must be a positive integer"),
+    );
+    expect(() => chunk([1, 2, 3], -1)).toThrow(
+      new TypeError("chunk size must be a positive integer"),
+    );
+    expect(() => chunk([1, 2, 3], 1.5)).toThrow(
+      new TypeError("chunk size must be a positive integer"),
+    );
   });
 
   test("ジェネリクスでオブジェクト配列も扱える", () => {

--- a/src/app/lib/lodash.test.ts
+++ b/src/app/lib/lodash.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "@jest/globals";
+import { chunk } from "./lodash";
+
+describe("chunk", () => {
+  test("sizeごとに配列を分割できる", () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  test("入力配列が空の場合は空配列を返す", () => {
+    expect(chunk([], 3)).toEqual([]);
+  });
+
+  test("size が 1 未満の場合は空配列を返す", () => {
+    expect(chunk([1, 2, 3], 0)).toEqual([]);
+    expect(chunk([1, 2, 3], -1)).toEqual([]);
+  });
+
+  test("ジェネリクスでオブジェクト配列も扱える", () => {
+    const input = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    expect(chunk(input, 2)).toEqual([
+      [{ id: "a" }, { id: "b" }],
+      [{ id: "c" }],
+    ]);
+  });
+});

--- a/src/app/lib/lodash.ts
+++ b/src/app/lib/lodash.ts
@@ -1,7 +1,7 @@
 // https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore?tab=readme-ov-file#_chunk
 export function chunk<T>(input: T[], size: number): T[][] {
-  if (size < 1) {
-    return [];
+  if (!Number.isInteger(size) || size < 1) {
+    throw new TypeError("chunk size must be a positive integer");
   }
 
   return input.reduce<T[][]>((acc, item, index) => {

--- a/src/app/lib/lodash.ts
+++ b/src/app/lib/lodash.ts
@@ -1,9 +1,16 @@
 // https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore?tab=readme-ov-file#_chunk
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function chunk(input: any[], size: number): any[][] {
-  return input.reduce((arr, item, idx) => {
-    return idx % size === 0
-      ? [...arr, [item]]
-      : [...arr.slice(0, -1), [...arr.slice(-1)[0], item]];
+export function chunk<T>(input: T[], size: number): T[][] {
+  if (size < 1) {
+    return [];
+  }
+
+  return input.reduce<T[][]>((acc, item, index) => {
+    if (index % size === 0) {
+      acc.push([item]);
+      return acc;
+    }
+
+    acc[acc.length - 1].push(item);
+    return acc;
   }, []);
 }


### PR DESCRIPTION
### Motivation
- `chunk` ユーティリティで使用されていた `any` を除去して型安全にし、`@typescript-eslint/no-explicit-any` の抑制コメントを不要にするための変更です。 
- 同時に動作検証のためのユニットテストを追加して回帰を防ぐことを目的としています.

### Description
- `src/app/lib/lodash.ts` の `chunk` をジェネリクス化して `export function chunk<T>(input: T[], size: number): T[][]` とし、`size < 1` の場合は空配列を返すガードを追加しました。 
- `src/app/lib/lodash.test.ts` を追加して、通常分割・空配列入力・不正サイズ（0 または負）・オブジェクト配列（ジェネリクス）を検証するユニットテストを実装しました。 
- 既存の `// eslint-disable-next-line @typescript-eslint/no-explicit-any` を削除し、型注釈で安全性を確保しています。 

### Testing
- `npm run format:check` は実行して成功しました（`prettier` チェック合格）。 
- `npm run lint` は環境依存で失敗しました（`eslint-config-next` が見つからないため実行不可）。 
- `npm run build` は依存未導入により失敗しました（`next` コマンド未検出）。 
- `npm test` は依存未導入により失敗しました（`jest` コマンド未検出）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad78012f3c832b8d9e9eb85c128c52)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added input validation to the chunk function to catch invalid chunk sizes with clear error messages.

* **Tests**
  * Added comprehensive test suite for the chunk function covering edge cases and various data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->