### PR TITLE
Add safe getCurrentRange helper to guard getRangeAt(0) access

### DIFF
--- a/src/app/pages/[title]/block/content/keyboardeventhandler/dom.ts
+++ b/src/app/pages/[title]/block/content/keyboardeventhandler/dom.ts
@@ -3,9 +3,7 @@ export function getTextsAroundCursor(): {
   afterCursor: string;
   startOffset: number;
 } {
-  const selection = window.getSelection();
-  // @owner Accessing `getRangeAt(0)` without checking `rangeCount` can throw when no selection exists.
-  const range = selection?.getRangeAt(0);
+  const range = getCurrentRange();
   const text = range?.startContainer.textContent;
   if (!text) {
     return { beforeCursor: "", afterCursor: "", startOffset: 0 };
@@ -16,9 +14,7 @@ export function getTextsAroundCursor(): {
 }
 
 export function extractTextsAroundCursor() {
-  const selection = window.getSelection();
-  // @owner Ensure `selection?.rangeCount > 0` before calling `getRangeAt(0)` to avoid exceptions.
-  const range = selection?.getRangeAt(0);
+  const range = getCurrentRange();
 
   let beforeCursor = true;
   const caretElement = range?.startContainer.parentElement;
@@ -48,6 +44,14 @@ export function extractTextsAroundCursor() {
     }
   }
   return { textBefore, textAfter };
+}
+
+function getCurrentRange(): Range | null {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    return null;
+  }
+  return selection.getRangeAt(0);
 }
 
 function extractTextContent(content: Element): string {


### PR DESCRIPTION
### Motivation
- Prevent runtime exceptions when no selection exists by guarding calls to `getRangeAt(0)` behind a small helper.

### Description
- Added `getCurrentRange()` which checks `window.getSelection()` and `selection.rangeCount` before returning `selection.getRangeAt(0)`, and replaced direct calls to `getRangeAt(0)` in `getTextsAroundCursor` and `extractTextsAroundCursor` with this helper.

### Testing
- Ran the project's TypeScript type-check and automated unit test suite; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b01dc39dc0832ba36d6fa8af4d20b5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text selection handling around cursor positions to gracefully manage cases where selections may be unavailable, preventing potential errors and ensuring stable operation.

* **Refactor**
  * Enhanced internal text range retrieval logic with improved null-safety checks for more robust behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->